### PR TITLE
Ajout condition pour tester taille ecran

### DIFF
--- a/R/build_website.R
+++ b/R/build_website.R
@@ -113,7 +113,11 @@ bs4_utilitr <-
     )
 
   bookdown::bs4_book(
-    extra_dependencies = extra_dependencies,
+    if (dev.size("cm")[[1]]<10) {
+      extra_dependencies = list()
+    } else {
+      extra_dependencies = extra_dependencies
+    },
     includes = includes,
     theme = theme(primary = primary,
                   secondary = secondary


### PR DESCRIPTION
PR (pour dépanner rapidement) en lien avec [cette issue](https://github.com/InseeFrLab/utilitR/issues/409) pour améliorer le rendu d'utilitr sur mobile.  

Une solution de fainéant 😅 qui permet d'avoir un affichage correct sur mobile sans avoir à ré-écrire de CSS (voir ma proposition dans l'issue d'utilitr)

Pour l'unité de dev.size(), j'ai pris le cm car les quelques tests que je viens de faire en pixels sur mon poste me paraissaient "bizarres" (à peine + de 750 pixels sur un pc...)

Sinon c'est peut-être mieux de le faire dans les règles de l'art avec du CSS.. donc ne tenez pas compte de cette PR 😃 